### PR TITLE
fix issue with std::array<double,4> cannot be cast to double[4]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 option(BUILD_SHARED_LIBS "build shared libs (true)" TRUE)
 
 find_package(CCP4 REQUIRED ccp4c)
-find_package(gemmi 0.6.4 CONFIG REQUIRED)
+find_package(gemmi 0.6.7 CONFIG REQUIRED)
 
 # FFTW2 - first search in the install path, then in the system
 find_library(FFTW3_LIBRARY NAMES fftw3f
@@ -23,7 +23,7 @@ find_package(Threads)
 include(${CMAKE_SOURCE_DIR}/cmake/source.cmake)
 
 set(PACKAGE "clipper")
-set(VERSION "3.0.1-dev") # might need to bump major version to 3?
+set(VERSION "3.0.3-dev") # might need to bump major version to 3?
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmakein
                ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
 

--- a/clipper.pc.cmakein
+++ b/clipper.pc.cmakein
@@ -8,5 +8,5 @@ Description: crystallographic automation and complex data manipulation libraries
 Version: @VERSION@
 Requires: @CLIPPER_REQUIRES@
 Libs: -L${libdir} -l$<TARGET_FILE_BASE_NAME:clipper-core> -l$<TARGET_FILE_BASE_NAME:clipper-contrib> -l$<TARGET_FILE_BASE_NAME:clipper-cns> -l$<TARGET_FILE_BASE_NAME:clipper-phs> -l$<TARGET_FILE_BASE_NAME:clipper-ccp4> -l$<TARGET_FILE_BASE_NAME:clipper-gemmi> -l$<TARGET_FILE_BASE_NAME:clipper-minimol> -l$<TARGET_FILE_BASE_NAME:clipper-cif> 
-Libs.private: -lm @PTHREAD_LIBS@
+Libs.private: @FFTW3F_LIBS@ -lm @PTHREAD_LIBS@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@

--- a/clipper/gemmi/clipper_gemmi.cpp
+++ b/clipper/gemmi/clipper_gemmi.cpp
@@ -328,9 +328,8 @@ HKL_data<data64::ABCD> GEMMI::as_HKL_data(
   HKL_data<data64::ABCD> hkl_data(hkl_info);
   data64::ABCD abcd;
   for (std::size_t i = 0; i < miller_indices.size(); i++) {
-    std::array<double, 4> datum = {data[0]->at(i), data[1]->at(i),
-                                   data[2]->at(i), data[3]->at(i)};
-    abcd.data_import(datum.begin());
+    double datum[4] = { data[0]->at( i ), data[1]->at( i ), data[2]->at( i ), data[3]->at( i ) };
+    abcd.data_import( datum );
     if (!hkl_data.set_data(Hkl(miller_indices[i]), abcd))
       Message::message(Message_fatal("GEMMI: Unable to set data for " +
                                      Hkl(miller_indices[i]).format()));


### PR DESCRIPTION
issue found by Stuart when compiling with newest emscripten compilers

stricter c++ standards no longer allow casting of std::array<double,4> to array[4], found in clipper_gemmi.cpp

